### PR TITLE
Sample computation script

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 NaturalShift is a .NET library useful to compute workshifts. Computation is based on genetic algoritms. Number of days, shifts and shifters can be configured, together with many other contraints and directives.
 
 # Quick example
-The following code starts computation of a workshift scheme 30 days long, with 14 shifts and 18 employees. The computation lasts 60 seconds.
+The following code starts computation of a workshift scheme 30 days long, with 14 shifts and 18 employees. The computation lasts 30 seconds.
 
 ```C#
 var problem = ProblemBuilder.Configure()
@@ -17,12 +17,14 @@ var solvingEnvironment = SolvingEnvironmentBuilder.Configure()
   .ForProblem(problem)
   .WithPopulationSize(100)
   .RenewingPopulationAfterSameFitnessEpochs(10)
-  .StoppingComputationAfter(60).Seconds
+  .StoppingComputationAfter(30).Seconds
   .Build();
 
-var solution = solvingEnvironment.Solve(); //takes about 60 seconds
+var solution = solvingEnvironment.Solve(); //takes about 30 seconds
 
 Console.WriteLine(solution);
+Console.WriteLine("Press a key...");
+Console.ReadLine();
 ```
 
 The best solution found during computation is printed to the console.


### PR DESCRIPTION
Sample script freezes the console after computation. Sample computation lasts 30 seconds.